### PR TITLE
Problems must be unwrapped

### DIFF
--- a/src/handling.ts
+++ b/src/handling.ts
@@ -58,7 +58,11 @@ const Err = <E>(error: E): ErrorType<E> => {
   };
 };
 
-function isProblem<T>(result: T | Problem<string>): result is Problem<string> {
+type Not<T, U> = T extends U ? never : T;
+
+function isProblem<T>(
+  result: Not<T, Result<unknown, unknown>> | Problem<string>
+): result is Problem<string> {
   return result instanceof Problem;
 }
 

--- a/src/tests/problem.test.ts
+++ b/src/tests/problem.test.ts
@@ -1,0 +1,17 @@
+import test from "ava";
+import invariant from "tests/invariant";
+import { isProblem, mayFail } from "ts-handling";
+
+test("isProblem isn't problem", (t) => {
+  const result = mayFail(() => ["not a problem"]).unwrap();
+  invariant(!isProblem(result));
+  t.deepEqual(result, ["not a problem"]);
+});
+
+test("isProblem is a problem", (t) => {
+  const result = mayFail(() => {
+    throw new Error("this is a problem");
+  }).unwrap();
+  invariant(isProblem(result));
+  t.is(result.error, "this is a problem");
+});

--- a/src/tests/problem.test.ts
+++ b/src/tests/problem.test.ts
@@ -15,3 +15,11 @@ test("isProblem is a problem", (t) => {
   invariant(isProblem(result));
   t.is(result.error, "this is a problem");
 });
+
+test("isProblem value must be unwrapped", (t) => {
+  const result = mayFail(() => ["not a problem"]);
+  // @ts-expect-error must call .unwrap() first
+  invariant(!isProblem(result));
+  invariant(!isProblem(result.unwrap()));
+  t.pass();
+});


### PR DESCRIPTION
A common mistake is to pass results into `isProblem` before calling `.unwrap()`. In this PR I propose enforcing a TypeScript compiler error to prevent these mistakes.