### PR TITLE
Don't export `Problem`

### DIFF
--- a/src/handling.ts
+++ b/src/handling.ts
@@ -60,9 +60,9 @@ const Err = <E>(error: E): ErrorType<E> => {
 
 type Not<T, U> = T extends U ? never : T;
 
-function isProblem<T>(
-  result: Not<T, Result<unknown, unknown>> | Problem<string>
-): result is Problem<string> {
+function isProblem<T, E = string>(
+  result: Not<T, Result<unknown, unknown>> | Problem<E>
+): result is Problem<E> {
   return result instanceof Problem;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,7 @@
 import { check, checkAsync } from "./check.js";
-import { Err, isProblem, Ok, Problem } from "./handling.js";
+import { Err, isProblem, Ok } from "./handling.js";
 import type { ExtractAsyncData, ExtractData, Result } from "./handling.js";
 import { mayFail, mayFailAsync } from "./mayFail.js";
 
-export {
-  check,
-  checkAsync,
-  Err,
-  isProblem,
-  mayFail,
-  mayFailAsync,
-  Ok,
-  Problem,
-};
+export { check, checkAsync, Err, isProblem, mayFail, mayFailAsync, Ok };
 export type { ExtractAsyncData, ExtractData, Result };

--- a/src/tests/unwrap.test.ts
+++ b/src/tests/unwrap.test.ts
@@ -1,5 +1,5 @@
 import invariant from "tests/invariant";
-import { Err, Ok, Problem, Result } from "ts-handling";
+import { Err, isProblem, Ok, Result } from "ts-handling";
 import { expect, test } from "vitest";
 
 const run = (succeed: boolean): Result<string, number> => {
@@ -8,12 +8,12 @@ const run = (succeed: boolean): Result<string, number> => {
 
 test("can unwrap fail", () => {
   const result = run(false).unwrap();
-  invariant(result instanceof Problem);
+  invariant(isProblem(result));
   expect(result.error).toBe(10);
 });
 
 test("can unwrap succeed", () => {
   const result = run(true).unwrap();
-  invariant(!(result instanceof Problem));
+  invariant(!isProblem(result));
   expect(result).toBe("success");
 });


### PR DESCRIPTION
In this PR I propose hiding the `Problem` class from public exports because it's prone to easy misuse. There's almost never a good reason to reference this class directly, yet it leads to subtle bugs when developers use `x instanceof Problem` instead of using `isProblem(x)`.